### PR TITLE
Fix issue with how a key is looked up

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,6 +1,7 @@
 KEYINT=100
-KEYBOOL=true
+KEYBOOLTRUE=true
 KEYSTR=hello
 #this is a comment
 TEST=d
 ARR=1,foo,true,false
+KEYBOOLFALSE=false

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 KEYINT=100
-KEYBOOL=true
+KEYBOOLTRUE=true
 KEYSTR=hello
 #this is a comment
 TEST=d
 ARR=1,foo,true,false
+KEYBOOLFALSE=false

--- a/src/easyconfig.service.ts
+++ b/src/easyconfig.service.ts
@@ -18,14 +18,14 @@ export class EasyconfigService {
   }
 
   get(key: string): any {
-    const val = this.envConfig[key];
+    const configExists = key in this.envConfig;
 
-    if (!val) {
+    if (!configExists) {
       this.logger.warn('The key was not found in config file 😕');
       return;
     }
 
-    return val;
+    return this.envConfig[key];
   }
 
   /**

--- a/test/unit/easyconfig.service.spec.ts
+++ b/test/unit/easyconfig.service.spec.ts
@@ -15,8 +15,12 @@ describe('EasyconfigService', () => {
     expect(service.get('KEYINT')).toEqual(100);
   });
 
-  it('should be return boolean', () => {
-    expect(service.get('KEYBOOL')).toEqual(true);
+  it('should be return a true boolean', () => {
+    expect(service.get('KEYBOOLTRUE')).toEqual(true);
+  });
+
+  it('should be return a false boolean', () => {
+    expect(service.get('KEYBOOLFALSE')).toEqual(false);
   });
 
   it('should be return string', () => {


### PR DESCRIPTION
When the config is parsed through `dotenvParseVariables` you can have configs that are boolean.

When we look them up, we must check their keys only, because the value can be false and would cause the config check to incorrectly assume the key was not found.