### PR TITLE
feat(config-option): add option to use a custom logger instead of NestJS logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ lerna-debug.log*
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
-!.vscode/launch.json
+!vscode/launch.json
 !.vscode/extensions.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,15 @@
         }
       }
     },
+    "@golevelup/nestjs-modules": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-modules/-/nestjs-modules-0.3.0.tgz",
+      "integrity": "sha512-seyGDA/fFb+Ch0dGefcnzRs9jydmSCBELgkFCNyU/o+tfXqIZKxF8un5RxYo30ncQOwD+KfGH8t4K6+qNNhaew==",
+      "dev": true,
+      "requires": {
+        "shortid": "^2.2.14"
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -4319,6 +4328,12 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.8.tgz",
+      "integrity": "sha512-g1z+n5s26w0TGKh7gjn7HCqurNKMZWzH08elXzh/gM/csQHd/UqDV6uxMghQYg9IvqRPm1QpeMk50YMofHvEjQ==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -4349,6 +4364,16 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
+    },
+    "nestjs-ogma": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nestjs-ogma/-/nestjs-ogma-2.0.3.tgz",
+      "integrity": "sha512-5Xb6DtqipxjIxVAxatXb4kBjMZ43r8BrjYCTi39sdizZkLy6aXbS5PtHqrZY5XVh9jlRHt3wIsxRgWOiGijIRA==",
+      "dev": true,
+      "requires": {
+        "@golevelup/nestjs-modules": "^0.3.0",
+        "ogma": "^2.0.0"
+      }
     },
     "next-tick": {
       "version": "1.0.0",
@@ -4523,6 +4548,12 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "ogma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ogma/-/ogma-2.0.1.tgz",
+      "integrity": "sha512-tiyfHaftlGCALh/lfsj4UNNsZHa6n/Til+WK86ST3nscRwh4fzAmg/PY1GfRuLG9JTnFBgbz067gnY3kwp5Fzg==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -5237,6 +5268,15 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "commitizen": "^4.0.3",
     "cz-conventional-changelog": "^3.0.2",
     "jest": "24.9.0",
+    "nestjs-ogma": "^2.0.3",
+    "ogma": "^2.0.1",
     "prettier": "1.19.1",
     "reflect-metadata": "0.1.13",
     "rimraf": "^3.0.0",

--- a/src/config.interface.ts
+++ b/src/config.interface.ts
@@ -1,3 +1,5 @@
+import { LoggerService } from '@nestjs/common';
+
 export interface Config {
 	/**
 	 * path to the file to load.
@@ -47,4 +49,10 @@ export interface Config {
 	 */
 
 	encoding?: string;
+
+	/**
+	 * This option allows you to pass in a pre-defined logger instance. The logger must implement the NestJS LoggerService interface
+	 */
+
+	 logger?: LoggerService;
 }

--- a/src/easyconfig.service.ts
+++ b/src/easyconfig.service.ts
@@ -3,16 +3,17 @@ import * as dotenvParseVariables from 'dotenv-parse-variables';
 import * as fs from 'fs';
 import { Config } from './config.interface';
 import * as path from 'path';
-import { Logger } from '@nestjs/common';
+import { Logger, LoggerService } from '@nestjs/common';
 import { EasyconfigError } from './easyconfig.error';
 
 export class EasyconfigService {
 	readonly sampleFile: string = '.env.sample';
 
 	private envConfig: { [key: string]: string };
-	private readonly logger = new Logger(EasyconfigService.name);
+	private readonly logger: LoggerService;
 
 	constructor(config?: Config) {
+		this.logger = config.logger || new Logger(EasyconfigService.name);
 		this.tryGetConfigFromEnv(config);
 		dotenv.config({ debug: config.debug, encoding: config.encoding });
 	}

--- a/test/unit/easyconfig.service.spec.ts
+++ b/test/unit/easyconfig.service.spec.ts
@@ -1,62 +1,78 @@
 import { EasyconfigService } from '../../src/easyconfig.service';
 import { EasyconfigError } from '../../src/easyconfig.error';
+import { Logger, LoggerService } from '@nestjs/common';
+import { OgmaService, OgmaModule } from 'nestjs-ogma';
+import { Ogma } from 'ogma';
 
 describe('EasyconfigService', () => {
-  const service: EasyconfigService = new EasyconfigService({
-    path: '.env.dev',
-    safe: true,
-  });
+	const service: EasyconfigService = new EasyconfigService({
+		path: '.env.dev',
+		safe: true,
+	});
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
 
-  it('should be return int', () => {
-    expect(service.get('KEYINT')).toEqual(100);
-  });
+	it('should be return int', () => {
+		expect(service.get('KEYINT')).toEqual(100);
+	});
 
-  it('should be return a true boolean', () => {
-    expect(service.get('KEYBOOLTRUE')).toEqual(true);
-  });
+	it('should be return a true boolean', () => {
+		expect(service.get('KEYBOOLTRUE')).toEqual(true);
+	});
 
-  it('should be return a false boolean', () => {
-    expect(service.get('KEYBOOLFALSE')).toEqual(false);
-  });
+	it('should be return a false boolean', () => {
+		expect(service.get('KEYBOOLFALSE')).toEqual(false);
+	});
 
-  it('should be return string', () => {
-    expect(service.get('KEYSTR')).toEqual('hello');
-  });
+	it('should be return string', () => {
+		expect(service.get('KEYSTR')).toEqual('hello');
+	});
 
-  it('should be return array', () => {
-    expect(service.get('ARR')).toEqual([1, 'foo', true, false]);
-  });
+	it('should be return array', () => {
+		expect(service.get('ARR')).toEqual([1, 'foo', true, false]);
+	});
 
-  it('should throw error when something goes wrong', () => {
-    try {
-      const anotherService: EasyconfigService = new EasyconfigService({
-        path: '.env.dev1',
-        safe: true,
-      });
-    } catch (err) {
-      expect(err).toBeInstanceOf(EasyconfigError);
-    }
-
-  });
+	it('should throw error when something goes wrong', () => {
+		try {
+			const anotherService: EasyconfigService = new EasyconfigService({
+				path: '.env.dev1',
+				safe: true,
+			});
+		} catch (err) {
+			expect(err).toBeInstanceOf(EasyconfigError);
+		}
+	});
 });
 
 describe('EasyconfigService with NODE_ENV', () => {
-  process.env.NODE_ENV = 'dev';
-  const service: EasyconfigService = new EasyconfigService({});
+	process.env.NODE_ENV = 'dev';
+	const service: EasyconfigService = new EasyconfigService({});
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
 });
 
 describe('EasyconfigService without NODE_ENV', () => {
-  const service: EasyconfigService = new EasyconfigService({});
+	const service: EasyconfigService = new EasyconfigService({});
 
-  it('should not be defined', () => {
-    expect(service).toBeDefined();
-  });
+	it('should not be defined', () => {
+		expect(service).toBeDefined();
+	});
+});
+
+describe('it should work with the logger option', () => {
+	it.each([
+		new Logger(EasyconfigService.name),
+		new OgmaService(
+			new Ogma({ logLevel: 'DEBUG', color: true}),
+			EasyconfigService.name,
+		),
+	])('it should work with any logger', (logger: LoggerService) => {
+		OgmaModule.forRoot(OgmaModule, {});
+		const service = new EasyconfigService({logger, path: '.env.dev', safe: true});
+		expect(service).toBeDefined();
+	});
 });


### PR DESCRIPTION
Add the `logger` property to the easyconfig options interface. If no logger is provided, fallback to
the NestJS logger. Otherwise use provided logger so long as it adheres to the LoggerService
interface.

re #124